### PR TITLE
Fixed change handler bug in 'choice' type

### DIFF
--- a/src/scripts/components/chips/chips.vue
+++ b/src/scripts/components/chips/chips.vue
@@ -108,7 +108,7 @@ export default {
               ? adapter.getIndexOfChipById(detail.chipId)
               : -1;
 
-            this.$emit(UI_CHIPS.EVENT.CHANGE, selectedIndex);
+            selectedIndex > -1 && this.$emit(UI_CHIPS.EVENT.CHANGE, selectedIndex);
           } else if (this.filterChips) {
             let selectedIndexes = [];
             chips.forEach((chip, index) => {


### PR DESCRIPTION
It should be trigger once when chip component on clicking but twice now.