### PR TITLE
fix: autocomplete error on enter (#78)

### DIFF
--- a/src/scripts/components/autocomplete/autocomplete.vue
+++ b/src/scripts/components/autocomplete/autocomplete.vue
@@ -427,9 +427,13 @@ export default {
             event.preventDefault();
             break;
           case KEYCODE.ENTER:
-            let selectedItem =
-              this.currentSuggestion.data[this.currentSuggestion.index];
-            this.handleSelected(selectedItem);
+            // Only autocomplete when text is inputted
+            if(this.inputValue.length > 0) {
+              // If no option is selected, use first option
+              let selectedItem =
+                this.currentSuggestion.data[this.currentSuggestion.index < MIN ? MIN : this.currentSuggestion.index];
+              this.handleSelected(selectedItem);
+            }
             event.preventDefault();
             break;
         }


### PR DESCRIPTION
(Don't know what branch to merge into, apologies in advance!!)

This fixes the bug in #78.

* When entering text into autocomplete and pressing enter without selecting any options via the arrow keys (e.g. currentSuggestion index = -1), select the FIRST option available in the list as if it were selected.
* Additional check if input is empty and enter is pressed, to NOT do the above functionality.

Before:
![ProblemRecreation](https://user-images.githubusercontent.com/17057173/144874390-e31ef5d7-0382-406c-8c54-b8e742cab712.gif)
After:
![ProblemResolution](https://user-images.githubusercontent.com/17057173/144874416-e125eb0b-28f7-472b-bf7b-3414ce376904.gif)

