### PR TITLE
Prevent small menu-in-dialogs h100%

### DIFF
--- a/src/styles/balm-ui/components/_mixins.scss
+++ b/src/styles/balm-ui/components/_mixins.scss
@@ -50,7 +50,7 @@
     display: flex;
 
     .mdc-deprecated-list {
-      height: 100%;
+      max-height: 100%;
       overflow-y: scroll;
     }
   }


### PR DESCRIPTION
Prevent small menu's to take up all vertical space as mentioned in #135 