### PR TITLE
fix(pagination): update `jumpPage` value when the `currentPage` is changed

### DIFF
--- a/docs/scripts/snippets/pagination/demo5.md
+++ b/docs/scripts/snippets/pagination/demo5.md
@@ -1,0 +1,24 @@
+```html
+<ui-pagination
+  v-model="page"
+  :total="total"
+  show-total
+  :page-size="[10, 25, 100]"
+  show-jumper
+>
+  <template #default="{ currentMinRow, currentMaxRow }">
+    {{ currentMinRow }} - {{ currentMaxRow }} / {{ total }}
+  </template>
+</ui-pagination>
+```
+
+```js
+export default {
+  data() {
+    return {
+      page: 1,
+      total: 500
+    };
+  }
+};
+```

--- a/docs/scripts/views/components/pagination.vue
+++ b/docs/scripts/views/components/pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-page name="pagination" demo-count="4">
+  <docs-page name="pagination" demo-count="5">
     <template #hero>
       <ui-pagination
         v-model="page"
@@ -67,6 +67,24 @@
       </div>
       <ui-snippet :code="$store.demos[4]"></ui-snippet>
     </section>
+
+    <section class="demo-wrapper">
+      <h6 :class="$tt('headline6')">1.5 Pagination with page size and jumper</h6>
+      <div class="demo">
+        <ui-pagination
+          v-model="page5"
+          :total="total5"
+          show-total
+          :page-size="[10, 25, 100]"
+          show-jumper
+        >
+          <template #default="{ currentMinRow, currentMaxRow }">
+            {{ currentMinRow }} - {{ currentMaxRow }} / {{ total5 }}
+          </template>
+        </ui-pagination>
+      </div>
+      <ui-snippet :code="$store.demos[5]"></ui-snippet>
+    </section>
   </docs-page>
 </template>
 
@@ -90,7 +108,9 @@ export default {
       page3: 1,
       total3: 100,
       page4: 1,
-      total4: 100
+      total4: 100,
+      page5: 1,
+      total5: 500
     };
   }
 };

--- a/src/scripts/components/pagination/pagination.vue
+++ b/src/scripts/components/pagination/pagination.vue
@@ -21,7 +21,7 @@
       <div class="mdc-data-table__pagination-navigation">
         <!-- Total -->
         <div v-if="showTotal" class="mdc-data-table__pagination-total">
-          <slot :currentMinRow="currentMinRow" :currentMaxRow="currentMaxRow">
+          <slot :current-min-row="currentMinRow" :current-max-row="currentMaxRow">
             {{ currentMinRow }}‑{{ currentMaxRow }} {{ ofText }} {{ total }}
           </slot>
         </div>
@@ -341,8 +341,8 @@ function handleClick(page) {
 }
 function handleChange() {
   let page = getPage(state.currentPage);
+  state.jumpPage = page;
   if (state.currentPage !== page) {
-    state.jumpPage = page;
     emit(UI_PAGINATION.EVENTS.CHANGE, +page);
   }
 


### PR DESCRIPTION
解决issue [#144](https://github.com/balmjs/balm-ui/issues/144)

问题描述:
当使用`pagination`组件的`show-jumper`属性时，如果修改了`pageSize`，我希望重置 `currentPage`为1，但此时`jumpPage`不会同步更新，比如仍为`3`
