### PR TITLE
fix(#153): expand all keys with props `defaultExpandedKeys`

### DIFF
--- a/docs/scripts/snippets/tree/demo4.md
+++ b/docs/scripts/snippets/tree/demo4.md
@@ -1,0 +1,56 @@
+```html
+<ui-tree
+  v-model="selectedValue"
+  :data="treeData"
+  :data-format="dataFormat"
+  :max-level="3"
+  autoExpandParent
+  :default-expanded-keys="defaultKeys"
+>
+  <p>selectedValue: {{ selectedValue }}</p>
+</ui-tree>
+```
+
+```js
+export default {
+  data() {
+    return {
+      dataFormat: { label: 'title', value: 'key' },
+      treeData: [{
+        title: 'node1',
+        key: '1',
+        children: [
+          {
+            title: 'node1-1',
+            key: '1-1',
+            children: [
+              {
+                title: 'node2',
+                key: '2',
+                children: [
+                  {
+                    title: 'node2-1',
+                    key: '2-1',
+                  },
+                ],
+              },
+            ]
+          },
+          {
+            title: 'node1-2',
+            key: '1-2',
+            children: [
+              {
+                title: 'node1-2-1',
+                key: '1-2-1'
+              }
+            ]
+          }
+        ],
+      },]
+      selectedValue: '1',
+      defaultKeys: ['1', '1-1', '2', '2-1'],
+    };
+  }
+};
+```

--- a/docs/scripts/views/components/tree.vue
+++ b/docs/scripts/views/components/tree.vue
@@ -127,7 +127,7 @@ export default {
             key: '1-1',
             children: [
               {
-                title: '2',
+                title: 'node2',
                 key: '2',
                 children: [
                   {

--- a/docs/scripts/views/components/tree.vue
+++ b/docs/scripts/views/components/tree.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-page name="tree" demo-count="3">
+  <docs-page name="tree" demo-count="4">
     <template #hero>
       <h1 :class="$tt('headline1')">Tree</h1>
     </template>
@@ -54,6 +54,26 @@
       </div>
       <ui-snippet :code="$store.demos[3]"></ui-snippet>
     </section>
+
+    <section class="demo-wrapper">
+      <h6 :class="$tt('headline6')">1.4 Use defaultExpandedKeys</h6>
+      <div class="demo">
+        <ui-tree
+          v-model="selectedValue4"
+          :data="treeData4"
+          :data-format="dataFormat"
+          :max-level="3"
+          auto-expand-parent
+          :default-expanded-keys="defaultKeys"
+        >
+          <p>selectedValue: {{ selectedValue4 }}</p>
+          <template #title="{ data }">
+            {{ data.title }}
+          </template>
+        </ui-tree>
+      </div>
+      <ui-snippet :code="$store.demos[4]"></ui-snippet>
+    </section>
   </docs-page>
 </template>
 
@@ -95,7 +115,41 @@ export default {
       selectedValue2: [],
       treeData3: [], // dig('0', -1),
       selectedValue3: ['0-0'],
-      keywords: ''
+      keywords: '',
+      defaultKeys: ['1', '1-1', '2', '2-1'],
+      selectedValue4: 'org2',
+      treeData4: [{
+        title: 'node1',
+        key: '1',
+        children: [
+          {
+            title: 'node1-1',
+            key: '1-1',
+            children: [
+              {
+                title: '2',
+                key: '2',
+                children: [
+                  {
+                    title: 'node2-1',
+                    key: '2-1',
+                  },
+                ],
+              },
+            ]
+          },
+          {
+            title: 'node1-2',
+            key: '1-2',
+            children: [
+              {
+                title: 'node1-2-1',
+                key: '1-2-1'
+              }
+            ]
+          }
+        ],
+      },]
     };
   },
   mounted() {

--- a/src/scripts/components/tree/mdc-tree.js
+++ b/src/scripts/components/tree/mdc-tree.js
@@ -280,6 +280,20 @@ class MdcTree {
     }
   }
 
+  static async handleExpandKeys(treeData, nodes, defaultExpandedKeys) {
+    const { dataFormat, nodeMap } = treeData;
+
+    for await (let node of nodes) {
+      const nodeKey = node[dataFormat.value];
+      const item = nodeMap.get(nodeKey);
+
+      defaultExpandedKeys.includes(nodeKey) && this.onExpand(treeData, item);
+      if (node.children && node.children.length) {
+        this.handleExpandKeys(treeData, node.children, defaultExpandedKeys)
+      }
+    }
+  }
+
   /** For init tree **/
   static async setExpanded(
     treeData,
@@ -289,17 +303,15 @@ class MdcTree {
     const { dataFormat, nodeMap } = treeData;
 
     if (autoExpandParent) {
-      const nodes = defaultExpandedKeys.length
-        ? nodeList.filter((node) =>
-            defaultExpandedKeys.includes(node[dataFormat.value])
-          )
-        : nodeList;
+      if (defaultExpandedKeys.length) {
+        this.handleExpandKeys(treeData, nodeList, defaultExpandedKeys)
+      } else {
+        for await (let node of nodeList) {
+          const nodeKey = node[dataFormat.value];
+          const item = nodeMap.get(nodeKey);
 
-      for await (let node of nodes) {
-        const nodeKey = node[dataFormat.value];
-        const item = nodeMap.get(nodeKey);
-
-        this.onExpand(treeData, item);
+          this.onExpand(treeData, item);
+        }
       }
     }
   }


### PR DESCRIPTION
In use, I found that passing `defaultExpandedKeys` did not expand all the nodes, so I tried to modify it locally, please help to review it~