### PR TITLE
feat(tree.vue): add new props autoExpandSelected and autoExpandAll

### DIFF
--- a/docs/scripts/docs/en/tree/tree.md
+++ b/docs/scripts/docs/en/tree/tree.md
@@ -15,6 +15,8 @@
 | `singleChecked`          | boolean       | `false` | Set single checked. Applicable only for the `multiple` tree. | 9.34.0  |
 | `loadData`               | function      | `null`  | Load data asynchronously.                                    |         |
 | `autoExpandParent`       | boolean       | `false` | Whether to automatically expand root parent(s) treeNode.     | 9.17.0  |
+| `autoExpandSelected`     | boolean       | `false` | Whether to automatically expand selected treeNode and it's parent treeNode.           |         |
+| `autoExpandAll`          | boolean       | `false` | Whether to automatically expand all treeNode.                |         |
 | `defaultExpandedKeys`    | array         | `[]`    | Specify the node keys of the default expanded treeNodes.     | 9.17.0  |
 
 - Default data format

--- a/docs/scripts/docs/zh/tree/tree.md
+++ b/docs/scripts/docs/zh/tree/tree.md
@@ -15,6 +15,8 @@
 | `singleChecked`          | boolean       | `false` | 启用树节点单节点选择。仅针对 `multiple` 树节点有效。 | 9.34.0  |
 | `loadData`               | function      | `null`  | 启用异步加载数据                                     |         |
 | `autoExpandParent`       | boolean       | `false` | 是否自动展开根父级树节点                             | 9.17.0  |
+| `autoExpandSelected`     | boolean       | `false` | 是否自动展开手动赋值选择的树节点和它的父级树节点           |         |
+| `autoExpandAll`          | boolean       | `false` | 是否自动展开所有树节点                |         |
 | `defaultExpandedKeys`    | array         | `[]`    | 指定默认展开的树节点的节点值                         | 9.17.0  |
 
 - 默认数据格式

--- a/docs/scripts/snippets/tree/demo5.md
+++ b/docs/scripts/snippets/tree/demo5.md
@@ -15,39 +15,41 @@ export default {
   data() {
     return {
       dataFormat: { label: 'title', value: 'key' },
-      treeData: [{
-        title: 'node1',
-        key: '1',
-        children: [
-          {
-            title: 'node1-1',
-            key: '1-1',
-            children: [
-              {
-                title: 'node2',
-                key: '2',
-                children: [
-                  {
-                    title: 'node2-1',
-                    key: '2-1',
-                  },
-                ],
-              },
-            ]
-          },
-          {
-            title: 'node1-2',
-            key: '1-2',
-            children: [
-              {
-                title: 'node1-2-1',
-                key: '1-2-1'
-              }
-            ]
-          }
-        ],
-      },]
-      selectedValue: '2',
+      treeData: [
+        {
+          title: 'node1',
+          key: '1',
+          children: [
+            {
+              title: 'node1-1',
+              key: '1-1',
+              children: [
+                {
+                  title: 'node1-1-1',
+                  key: '1-1-1',
+                  children: [
+                    {
+                      title: 'node1-1-1-1',
+                      key: '1-1-1-1'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              title: 'node1-2',
+              key: '1-2',
+              children: [
+                {
+                  title: 'node1-2-1',
+                  key: '1-2-1'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      selectedValue: '1-1-1',
     };
   }
 };

--- a/docs/scripts/snippets/tree/demo5.md
+++ b/docs/scripts/snippets/tree/demo5.md
@@ -1,0 +1,54 @@
+```html
+<ui-tree
+  v-model="selectedValue"
+  :data="treeData"
+  :data-format="dataFormat"
+  :max-level="3"
+  autoExpandSelected
+>
+  <p>selectedValue: {{ selectedValue }}</p>
+</ui-tree>
+```
+
+```js
+export default {
+  data() {
+    return {
+      dataFormat: { label: 'title', value: 'key' },
+      treeData: [{
+        title: 'node1',
+        key: '1',
+        children: [
+          {
+            title: 'node1-1',
+            key: '1-1',
+            children: [
+              {
+                title: 'node2',
+                key: '2',
+                children: [
+                  {
+                    title: 'node2-1',
+                    key: '2-1',
+                  },
+                ],
+              },
+            ]
+          },
+          {
+            title: 'node1-2',
+            key: '1-2',
+            children: [
+              {
+                title: 'node1-2-1',
+                key: '1-2-1'
+              }
+            ]
+          }
+        ],
+      },]
+      selectedValue: '2',
+    };
+  }
+};
+```

--- a/docs/scripts/snippets/tree/demo6.md
+++ b/docs/scripts/snippets/tree/demo6.md
@@ -1,0 +1,54 @@
+```html
+<ui-tree
+  v-model="selectedValue"
+  :data="treeData"
+  :data-format="dataFormat"
+  :max-level="3"
+  autoExpandAll
+>
+  <p>selectedValue: {{ selectedValue }}</p>
+</ui-tree>
+```
+
+```js
+export default {
+  data() {
+    return {
+      dataFormat: { label: 'title', value: 'key' },
+      treeData: [{
+        title: 'node1',
+        key: '1',
+        children: [
+          {
+            title: 'node1-1',
+            key: '1-1',
+            children: [
+              {
+                title: 'node2',
+                key: '2',
+                children: [
+                  {
+                    title: 'node2-1',
+                    key: '2-1',
+                  },
+                ],
+              },
+            ]
+          },
+          {
+            title: 'node1-2',
+            key: '1-2',
+            children: [
+              {
+                title: 'node1-2-1',
+                key: '1-2-1'
+              }
+            ]
+          }
+        ],
+      },]
+      selectedValue: '1',
+    };
+  }
+};
+```

--- a/docs/scripts/snippets/tree/demo6.md
+++ b/docs/scripts/snippets/tree/demo6.md
@@ -15,39 +15,41 @@ export default {
   data() {
     return {
       dataFormat: { label: 'title', value: 'key' },
-      treeData: [{
-        title: 'node1',
-        key: '1',
-        children: [
-          {
-            title: 'node1-1',
-            key: '1-1',
-            children: [
-              {
-                title: 'node2',
-                key: '2',
-                children: [
-                  {
-                    title: 'node2-1',
-                    key: '2-1',
-                  },
-                ],
-              },
-            ]
-          },
-          {
-            title: 'node1-2',
-            key: '1-2',
-            children: [
-              {
-                title: 'node1-2-1',
-                key: '1-2-1'
-              }
-            ]
-          }
-        ],
-      },]
-      selectedValue: '1',
+      treeData: [
+        {
+          title: 'node1',
+          key: '1',
+          children: [
+            {
+              title: 'node1-1',
+              key: '1-1',
+              children: [
+                {
+                  title: 'node1-1-1',
+                  key: '1-1-1',
+                  children: [
+                    {
+                      title: 'node1-1-1-1',
+                      key: '1-1-1-1'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              title: 'node1-2',
+              key: '1-2',
+              children: [
+                {
+                  title: 'node1-2-1',
+                  key: '1-2-1'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      selectedValue: '1-1-1',
     };
   }
 };

--- a/docs/scripts/views/components/tree.vue
+++ b/docs/scripts/views/components/tree.vue
@@ -77,6 +77,8 @@
 
     <section class="demo-wrapper">
       <h6 :class="$tt('headline6')">1.5 Autoexpand SelectedValue Node</h6>
+      <ui-button raised @click="selectedValue5 = '1-1-1'">Select node 1-1-1</ui-button>
+      <ui-button style="margin: 0 8px;" raised @click="selectedValue5 = '1-2-1'">Select node 1-2-1</ui-button>
       <div class="demo">
         <ui-tree
           v-model="selectedValue5"
@@ -156,7 +158,7 @@ export default {
       keywords: '',
       defaultKeys: ['1', '1-2', '1-2-1'],
       selectedValue4: '1',
-      selectedValue5: '1-1',
+      selectedValue5: '1-1-1',
       treeData4: [
         {
           title: 'node1',

--- a/docs/scripts/views/components/tree.vue
+++ b/docs/scripts/views/components/tree.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-page name="tree" demo-count="4">
+  <docs-page name="tree" demo-count="6">
     <template #hero>
       <h1 :class="$tt('headline1')">Tree</h1>
     </template>
@@ -74,6 +74,44 @@
       </div>
       <ui-snippet :code="$store.demos[4]"></ui-snippet>
     </section>
+
+    <section class="demo-wrapper">
+      <h6 :class="$tt('headline6')">1.5 Autoexpand SelectedValue Node</h6>
+      <div class="demo">
+        <ui-tree
+          v-model="selectedValue5"
+          :data="treeData4"
+          :data-format="dataFormat"
+          :max-level="3"
+          auto-expand-selected
+        >
+          <p>selectedValue: {{ selectedValue5 }}</p>
+          <template #title="{ data }">
+            {{ data.title }}
+          </template>
+        </ui-tree>
+      </div>
+      <ui-snippet :code="$store.demos[5]"></ui-snippet>
+    </section>
+
+    <section class="demo-wrapper">
+      <h6 :class="$tt('headline6')">1.6 Autoexpand All Node</h6>
+      <div class="demo">
+        <ui-tree
+          v-model="selectedValue5"
+          :data="treeData4"
+          :data-format="dataFormat"
+          :max-level="3"
+          auto-expand-all
+        >
+          <p>selectedValue: {{ selectedValue5 }}</p>
+          <template #title="{ data }">
+            {{ data.title }}
+          </template>
+        </ui-tree>
+      </div>
+      <ui-snippet :code="$store.demos[6]"></ui-snippet>
+    </section>
   </docs-page>
 </template>
 
@@ -116,8 +154,9 @@ export default {
       treeData3: [], // dig('0', -1),
       selectedValue3: ['0-0'],
       keywords: '',
-      defaultKeys: ['1', '1-1', '1-2', '2'],
+      defaultKeys: ['1', '1-2', '1-2-1'],
       selectedValue4: '1',
+      selectedValue5: '1-1',
       treeData4: [
         {
           title: 'node1',
@@ -128,12 +167,12 @@ export default {
               key: '1-1',
               children: [
                 {
-                  title: 'node2',
-                  key: '2',
+                  title: 'node1-1-1',
+                  key: '1-1-1',
                   children: [
                     {
-                      title: 'node2-1',
-                      key: '2-1'
+                      title: 'node1-1-1-1',
+                      key: '1-1-1-1'
                     }
                   ]
                 }

--- a/src/scripts/components/tree/mdc-tree.js
+++ b/src/scripts/components/tree/mdc-tree.js
@@ -39,6 +39,7 @@ const getNode = (
 };
 
 let selectedNodes = [];
+let parentKeys = [];
 
 class MdcTree {
   constructor(treeData) {
@@ -299,13 +300,70 @@ class MdcTree {
     }
   }
 
+  static async handleExpandAll(treeData, nodes) {
+    const { dataFormat, nodeMap } = treeData;
+
+    for await (let node of nodes) {
+      const nodeKey = node[dataFormat.value];
+      const item = nodeMap.get(nodeKey);
+
+      this.onExpand(treeData, item);
+      if (item.children && item.children.length) {
+        this.handleExpandAll(treeData, item.children);
+      }
+    }
+  }
+
+  static async findTreeNode(tree, key, value) {
+    if (tree[key] === value)
+      return tree
+
+    if (tree.children && tree.children.length) {
+      for (let i = 0; i < tree.children.length; i++) {
+        const node = await this.findTreeNode(tree.children[i], key, value)
+        if (node !== null)
+          return node
+      }
+    }
+    return null
+  }
+
+  static toReverseArray(arr) {
+    const newArr = [];
+    for (let i = arr.length - 1; i >= 0; i--) {
+      newArr.push(arr[i]);
+    }
+    return newArr
+  }
+
+  static async handleAutoExpandSelected(nodeList, key, selectedValue, treeData) {
+    const result = await this.findTreeNode(nodeList[0], key, selectedValue)
+    parentKeys.push(result[key])
+    if (result.parentKey) {
+      this.handleAutoExpandSelected(nodeList, key, result.parentKey, treeData)
+    }
+
+    if (!result.parentKey) {
+      const reversedArr = this.toReverseArray(parentKeys)
+      treeData && this.handleExpandKeys(treeData, nodeList, reversedArr);
+    }
+  }
+
   /** For init tree **/
   static async setExpanded(
     treeData,
     nodeList,
-    { autoExpandParent, defaultExpandedKeys }
+    { autoExpandParent, defaultExpandedKeys, autoExpandSelected, autoExpandAll }
   ) {
-    const { dataFormat, nodeMap } = treeData;
+    const { dataFormat, nodeMap, selectedValue } = treeData;
+
+    if (autoExpandAll) {
+      this.handleExpandAll(treeData, nodeList)
+    }
+
+    if (autoExpandSelected) {
+      this.handleAutoExpandSelected(nodeList, 'key', selectedValue, treeData)
+    }
 
     if (autoExpandParent) {
       if (defaultExpandedKeys.length) {

--- a/src/scripts/components/tree/tree.vue
+++ b/src/scripts/components/tree/tree.vue
@@ -183,17 +183,19 @@ function init(originData = props.data) {
       autoExpandAll: props.autoExpandAll
     });
 
-    MdcTree.setSelected(state.treeData, state.treeData.selectedValue);
+    MdcTree.setSelected(state.treeData, state.treeData.selectedValue, state.nodeList, { autoExpandSelected: props.autoExpandSelected });
   }
 }
 
 function updateSelectedValue(val, oldVal = []) {
   nextTick(() => {
     if (oldVal.length) {
-      MdcTree.resetSelected(state.treeData, oldVal);
+      MdcTree.resetSelected(state.treeData, oldVal, state.nodeList, {
+        autoExpandSelected: props.autoExpandSelected
+      });
     }
 
-    MdcTree.setSelected(state.treeData, val);
+    MdcTree.setSelected(state.treeData, val, state.nodeList, { autoExpandSelected: props.autoExpandSelected });
     state.treeData.selectedValue = val;
   });
 }

--- a/src/scripts/components/tree/tree.vue
+++ b/src/scripts/components/tree/tree.vue
@@ -88,7 +88,15 @@ const props = defineProps({
   defaultExpandedKeys: {
     type: Array,
     default: () => []
-  }
+  },
+  autoExpandSelected: {
+    type: Boolean,
+    default: false,
+  },
+  autoExpandAll: {
+    type: Boolean,
+    default: false
+  },
 });
 
 const emit = defineEmits([UI_TREE.EVENTS.CHANGE, UI_TREE.EVENTS.SELECTED]);
@@ -170,7 +178,9 @@ function init(originData = props.data) {
   if (state.nodeList.length) {
     MdcTree.setExpanded(state.treeData, state.nodeList, {
       autoExpandParent: props.autoExpandParent,
-      defaultExpandedKeys: props.defaultExpandedKeys
+      defaultExpandedKeys: props.defaultExpandedKeys,
+      autoExpandSelected: props.autoExpandSelected,
+      autoExpandAll: props.autoExpandAll
     });
 
     MdcTree.setSelected(state.treeData, state.treeData.selectedValue);


### PR DESCRIPTION
在使用`ui-tree`的时候，发现当手动修改 `ui-tree` 的 `v-mode` 值后，树的展开状态没有变化，所以希望增加两个属性 `autoExpandSelected` 和 `autoExpandAll` 。

1. 在手动设置 `ui-tree` 的值后，可以自动展开对应的树节点和其对应的父级节点

2. 当节点不太多时，可以选择默认展开所有的树节点

https://github.com/balmjs/balm-ui/assets/23629097/20afec81-1c10-417b-8b7b-c02a3d89e0bc