### PR TITLE
feat(tree-node.vue): add condition to check if item is disabled before calling MdcTree.onSelect() function

### DIFF
--- a/src/scripts/components/tree/tree-node.vue
+++ b/src/scripts/components/tree/tree-node.vue
@@ -129,7 +129,9 @@ function handleExpand(item) {
   MdcTree.onExpand(props.treeData, item);
 }
 function handleSelect(item) {
-  MdcTree.onSelect(props.treeData, item);
+  if (!item.disabled) {
+    MdcTree.onSelect(props.treeData, item);
+  }
 }
 function handleCheck(item) {
   if (!item.disabled) {


### PR DESCRIPTION
In some scenarios, when select tree node and `UiTree` is not multiple, I hope that disabled node can't be select, just can be expanded .

So add this condition.