### PR TITLE
fix(textfield.vue): Component losing focus state when clearing value while typing  (fix #179)

### DIFF
--- a/src/scripts/components/textfield/textfield.vue
+++ b/src/scripts/components/textfield/textfield.vue
@@ -265,6 +265,7 @@ const isTextarea = computed(() => props.inputType === 'textarea');
 const isTextfieldPlus = computed(() =>
   UI_TEXTFIELD.PLUS_COMPONENTS.includes(parent.type.name)
 );
+const isDatepicker = computed(() => parent.type.name === 'UiDatepicker');
 const hasLeadingIcon = computed(
   () => !!(materialIcon.value || props.withLeadingIcon || hasBeforeSlot())
 );
@@ -329,9 +330,11 @@ onMounted(() => {
             );
         } catch (e) {}
 
-        setTimeout(() => {
-          state.$textField.foundation.deactivateFocus();
-        }, 1);
+        if(isDatepicker.value) {
+          setTimeout(() => {
+            state.$textField.foundation.deactivateFocus();
+          }, 1);
+        }
       }
     }
   );


### PR DESCRIPTION
A deal was added to remove focus only when UIDatePicker, which is the expected behavior.