### PR TITLE
feat(ui-tree): set class for disabled tree node

### DIFF
--- a/docs/scripts/snippets/tree/demo7.md
+++ b/docs/scripts/snippets/tree/demo7.md
@@ -1,0 +1,38 @@
+```html
+<ui-tree
+  v-model="selectedValue"
+  :data="treeData"
+  :data-format="dataFormat"
+  :max-level="3"
+  auto-expand-all
+>
+  <template #title="{ data }">
+    {{ data.title }}
+  </template>
+</ui-tree>
+```
+
+```js
+export default {
+  data() {
+    return {
+      dataFormat: { label: 'title', value: 'key', disabled: 'disabled' },
+      treeData: [
+        {
+          title: 'node1',
+          key: '1',
+          disabled: true,
+          children: [
+            {
+              title: 'node1-1',
+              key: '1-1',
+              disabled: false,
+            },
+          ]
+        }
+      ],
+      selectedValue: '1-1',
+    };
+  }
+};
+```

--- a/docs/scripts/views/components/tree.vue
+++ b/docs/scripts/views/components/tree.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-page name="tree" demo-count="6">
+  <docs-page name="tree" demo-count="7">
     <template #hero>
       <h1 :class="$tt('headline1')">Tree</h1>
     </template>
@@ -120,6 +120,25 @@
       </div>
       <ui-snippet :code="$store.demos[6]"></ui-snippet>
     </section>
+    <section class="demo-wrapper">
+      <h6 :class="$tt('headline6')">
+        1.7 Disabled tree node
+      </h6>
+      <div class="demo">
+        <ui-tree
+          v-model="selectedValue6"
+          :data="treeData5"
+          :data-format="dataFormat"
+          :max-level="3"
+          auto-expand-all
+        >
+          <template #title="{ data }">
+            {{ data.title }}
+          </template>
+        </ui-tree>
+      </div>
+      <ui-snippet :code="$store.demos[7]"></ui-snippet>
+    </section>
   </docs-page>
 </template>
 
@@ -154,7 +173,7 @@ function dig(path = '0', level = 0) {
 export default {
   data() {
     return {
-      dataFormat: { label: 'title', value: 'key' },
+      dataFormat: { label: 'title', value: 'key', 'disabled': 'disabled' },
       treeData1: [], // dig('0', 2),
       selectedValue1: '',
       treeData2: [], // dig('1', 2),
@@ -165,6 +184,7 @@ export default {
       defaultKeys: ['1', '1-2', '1-2-1'],
       selectedValue4: '1',
       selectedValue5: '1-1-1',
+      selectedValue6: '1-1',
       treeData4: [
         {
           title: 'node1',
@@ -196,6 +216,20 @@ export default {
                 }
               ]
             }
+          ]
+        }
+      ],
+      treeData5: [
+        {
+          title: 'node1',
+          key: '1',
+          disabled: true,
+          children: [
+            {
+              title: 'node1-1',
+              key: '1-1',
+              disabled: false,
+            },
           ]
         }
       ]

--- a/src/scripts/components/tree/tree-node.vue
+++ b/src/scripts/components/tree/tree-node.vue
@@ -71,6 +71,7 @@
 
         <label
           class="mdc-tree-node__label"
+          :class="nodeData.disabled ? 'mdc-tree-node__label__disabled' : ''"
           @click.prevent="
             treeData.multiple ? handleCheck(nodeData) : handleSelect(nodeData)
           "

--- a/src/styles/balm-ui/components/tree/_ui-tree.scss
+++ b/src/styles/balm-ui/components/tree/_ui-tree.scss
@@ -51,3 +51,15 @@
   flex: 1;
   padding: tree-variables.$label-padding;
 }
+
+.mdc-tree-node__label:hover {
+  cursor: pointer;
+}
+
+.mdc-tree-node__label__disabled {
+  color: tree-variables.$disabled-color;
+}
+
+.mdc-tree-node__label__disabled:hover {
+  cursor: default !important;
+}

--- a/src/styles/balm-ui/components/tree/_variables.scss
+++ b/src/styles/balm-ui/components/tree/_variables.scss
@@ -11,3 +11,4 @@ $selected-background-color: rgba(
   0.12
 ) !default;
 $selected-color: theme-color.prop-value(on-surface) !default;
+$disabled-color: rgba(theme-color.prop-value(on-surface), 0.38),


### PR DESCRIPTION
Hi bro ~  目前 <ui-tree>组件没有对禁止点击的节点设置特别的样式，我在使用中发现需要给设置了 { disabled: true } 的节点置灰，以突出展示效果，抽空帮忙review一下~ 