### PR TITLE
fix(mdc-tree.js): Modify the updateNode fn to support new fields

### DIFF
--- a/src/scripts/components/tree/mdc-tree.js
+++ b/src/scripts/components/tree/mdc-tree.js
@@ -514,7 +514,7 @@ class MdcTree {
 
     const nodeKey = originNodeData[value];
     const item = nodeMap.get(nodeKey);
-    Object.keys(item).forEach((key) => {
+    Object.keys(originNodeData).forEach((key) => {
       if (typeof originNodeData[key] !== 'undefined') {
         item[key] = originNodeData[key];
       }


### PR DESCRIPTION
目的: 修改 `updateNode` 方法中的遍历条件，使用 `originNodeData`, 从而支持向treeData源数据中新增字段，以便做一些特殊的判断。

比如: 
```html
<ui-tree ref="treeRef">
  <template #after="{ data }">
            <span
              style="display: inline-block;border: 1px solid #111; padding: 2px 4px; margin-left: 8px; cursor: pointer;"
              @click="updateTreeNode(data)"
            >编辑</span>
      </template>
  <template #before="{ data }">
            <div v-if="data.isMode && data.isMode === 'edit'">
              <input
                type="text"
                v-model="data.title"
                @keyup.enter="handleEnter(data)"
                ref="treeInputRef"
              />
              <span @click="handleEnter(data)">✅</span>
            </div>
          </template>
</ui-tree>
```

```js
updateTreeNode(nodeData) {
    this.$refs.treeRef.updateNode('update', nodeData.parentKey, { ...nodeData, isMode: 'edit' })
  }
```

当需要在<ui-tree>组件中使用slot时，需要通过一个特殊字段来判断，是否展示input输入框进行动态的编辑节点，目前是无法满足的，因为不能向原数组中新增字段，故有此更改。 