### PR TITLE
Remove FIX comment marker from _ui-form.scss

### DIFF
--- a/src/styles/balm-ui/components/form/_ui-form.scss
+++ b/src/styles/balm-ui/components/form/_ui-form.scss
@@ -117,7 +117,7 @@
 .mdc-form--actions-center {
   .mdc-form__actions {
     justify-content: center;
-    padding-left: 0; // FIX: padding left bug for center
+    padding-left: 0;
   }
 }
 


### PR DESCRIPTION
Fixes padding left bug marker for center alignment by removing the comment tag.

---
*PR created automatically by Jules for task [16972144135866107404](https://jules.google.com/task/16972144135866107404) started by @elf-mouse*