### PR TITLE
fix: apply position relative to fix cell z-index

### DIFF
--- a/src/styles/balm-ui/components/table/_ui-table.scss
+++ b/src/styles/balm-ui/components/table/_ui-table.scss
@@ -55,6 +55,7 @@
   width: 100%;
 
   .mdc-data-table__cell {
+    position: relative;
     background-color: white;
     z-index: 1; // FIX: for data input components
   }


### PR DESCRIPTION
Adds `position: relative` to `.mdc-data-table--fixed .mdc-data-table__cell` to ensure that the `z-index: 1` rule applies correctly for data input components within the cell.

---
*PR created automatically by Jules for task [7027154899149387296](https://jules.google.com/task/7027154899149387296) started by @elf-mouse*